### PR TITLE
Extra check for channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ function Hermes (opts, socketOpts) {
         }
         else {
           debug('subscribeCallback cannot ack. channel does not exist');
+          _this.emit('error', new Error('Cannot ack. Channel does not exist'));
         }
       });
     };

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ function Hermes (opts, socketOpts) {
       cb.name
     ].join('-');
     _this.consumerTags[consumerTag] = Array.prototype.slice.call(arguments);
-    _this._channel.consume(queueName, subscribeCallback(cb), {
+    _this._channel.consume(queueName, _this._subscribeCallback(cb), {
       consumerTag: consumerTag
     });
   }
@@ -158,29 +158,6 @@ function Hermes (opts, socketOpts) {
         cb.apply(_this, arguments);
       }
     });
-  }
-  /**
-   * @param {Function} cb
-   * @return Function
-   */
-  function subscribeCallback (cb) {
-    debug('subscribeCallback');
-    return function (msg) {
-      if (!msg) {
-        debug('subscribeCallback invalid message', msg);
-        return;
-      }
-      cb(JSON.parse(msg.content.toString()), function done () {
-        if (_this._channel) {
-          debug('subscribeCallback done');
-          _this._channel.ack(msg);
-        }
-        else {
-          debug('subscribeCallback cannot ack. channel does not exist');
-          _this.emit('error', new Error('Cannot ack. Channel does not exist'));
-        }
-      });
-    };
   }
   return this;
 }
@@ -366,3 +343,28 @@ Hermes.prototype.close = function (cb) {
 
   return this;
 };
+
+/**
+ * @param {Function} cb
+ * @return Function
+ */
+Hermes.prototype._subscribeCallback = function (cb) {
+  var _this = this;
+  debug('_subscribeCallback');
+  return function (msg) {
+    if (!msg) {
+      debug('_subscribeCallback invalid message', msg);
+      return;
+    }
+    cb(JSON.parse(msg.content.toString()), function done () {
+      if (_this._channel) {
+        debug('_subscribeCallback done');
+        _this._channel.ack(msg);
+      }
+      else {
+        debug('_subscribeCallback cannot ack. channel does not exist');
+        _this.emit('error', new Error('Cannot ack. Channel does not exist'));
+      }
+    });
+  };
+}

--- a/index.js
+++ b/index.js
@@ -171,8 +171,13 @@ function Hermes (opts, socketOpts) {
         return;
       }
       cb(JSON.parse(msg.content.toString()), function done () {
-        debug('subscribeCallback done');
-        _this._channel.ack(msg);
+        if (_this._channel) {
+          debug('subscribeCallback done');
+          _this._channel.ack(msg);
+        }
+        else {
+          debug('subscribeCallback cannot ack. channel does not exist');
+        }
       });
     };
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -307,7 +307,7 @@ describe('hermes', function () {
     });
 
     describe('#_subscribeCallback', function () {
-      it('should emit an error if channgel is null', function (done) {
+      it('should emit an error if channel is null', function (done) {
         var hermes = new Hermes(connectionOpts.standard);
         hermes.on('error', function (err) {
           expect(err).to.exist();


### PR DESCRIPTION
I'm adding this check because sometimes I see `_this._channel.ack(msg); TypeError: Cannot call method 'ack' of undefined` error in our tests.

Let us not crash in this case but just propagate and log error in a normal way in the client.

I'm guessing this error can happen when we closed connection and job finished after that.